### PR TITLE
Stop custom camera

### DIFF
--- a/Example-App/Docs-Examples/Documentation.docc/Documentation.md
+++ b/Example-App/Docs-Examples/Documentation.docc/Documentation.md
@@ -8,13 +8,13 @@ Take a look through each class to see how to implement all the features with Ago
 
 ## Topics
 
-### Getting Started
+### Get started
 
 - ``GettingStartedView``
 - ``AgoraManager``
 - ``AgoraVideoCanvasView``
 
-### Develop
+### Core functionality
 
 - ``TokenAuthenticationView``
 - ``CallQualityView``
@@ -23,7 +23,7 @@ Take a look through each class to see how to implement all the features with Ago
 - ``ScreenShareAndVolumeView``
 - ``CustomAudioVideoView``
 
-### Passing Parameters
+### Passing parameters
 
 - ``ChannelInputView``
 - ``TokenAuthInputView``
@@ -31,7 +31,7 @@ Take a look through each class to see how to implement all the features with Ago
 - ``CustomCameraInputView``
 - ``ProxyInputView``
 
-### AgoraManager Subclasses
+### AgoraManager subclasses
 
 - ``CallQualityManager``
 - ``CloudProxyManager``

--- a/Example-App/Docs-Examples/Utilities/PassParamPages/CustomCameraInputView.swift
+++ b/Example-App/Docs-Examples/Utilities/PassParamPages/CustomCameraInputView.swift
@@ -51,6 +51,8 @@ public struct CustomCameraInputView<Content: HasCustomVideoInput>: View {
                     Text("Join Channel")
                 }).disabled(channelId.isEmpty)
                     .buttonStyle(.borderedProminent)
+            }.onAppear {
+                channelId = DocsAppConfig.shared.channel
             }
         } else {
             Text("No cameras available.")

--- a/Example-App/Docs-Examples/Utilities/PassParamPages/EncryptionKeysInputView.swift
+++ b/Example-App/Docs-Examples/Utilities/PassParamPages/EncryptionKeysInputView.swift
@@ -59,6 +59,8 @@ public struct EncryptionKeysInputView<Content: HasEncryptionInput>: View {
                 Text("Join Channel")
             }.buttonStyle(.borderedProminent)
                 .disabled(channelId.isEmpty || encryptionKey.isEmpty || encryptionSalt.isEmpty)
+        }.onAppear {
+            channelId = DocsAppConfig.shared.channel
         }
     }
 }

--- a/Example-App/Docs-Examples/Utilities/PassParamPages/ProxyInputView.swift
+++ b/Example-App/Docs-Examples/Utilities/PassParamPages/ProxyInputView.swift
@@ -65,6 +65,8 @@ public struct ProxyInputView<Content: HasProxyServerInput>: View {
             Spacer()
             Text("Make sure you have enabled Cloud Proxy in Agora's Console")
                 .font(.callout).foregroundColor(.accentColor).multilineTextAlignment(.center)
+        }.onAppear {
+            channelId = DocsAppConfig.shared.channel
         }
     }
 }

--- a/Example-App/Docs-Examples/Utilities/PassParamPages/TokenAuthInputView.swift
+++ b/Example-App/Docs-Examples/Utilities/PassParamPages/TokenAuthInputView.swift
@@ -48,6 +48,8 @@ public struct TokenAuthInputView<Content: HasTokenServerInput>: View {
                 Text("Join Channel")
             }).disabled(channelId.isEmpty || tokenUrl.isEmpty)
                 .buttonStyle(.borderedProminent)
+        }.onAppear {
+            channelId = DocsAppConfig.shared.channel
         }
     }
 }

--- a/custom-video-and-audio/CustomAudioVideoView.swift
+++ b/custom-video-and-audio/CustomAudioVideoView.swift
@@ -75,6 +75,14 @@ class CustomAudioVideoManager: AgoraManager, AgoraCameraSourcePushDelegate {
         return super.joinChannel(channel, token: token, uid: uid, info: info)
     }
 
+    @discardableResult
+    override func leaveChannel(leaveChannelBlock: ((AgoraChannelStats) -> Void)? = nil) -> Int32 {
+        // Need to stop the capture on exit
+        pushSource?.stopCapture()
+        pushSource = nil
+        return super.leaveChannel(leaveChannelBlock: leaveChannelBlock)
+    }
+
     override func rtcEngine(
         _ engine: AgoraRtcEngineKit, didJoinChannel channel: String, withUid uid: UInt, elapsed: Int
     ) {


### PR DESCRIPTION
Fix: after opening custom camera once no other view worked. Fixed by calling stopCapture.

Updated documentation.