### PR TITLE
macOS Flag Fixes

### DIFF
--- a/ensure-channel-quality/CallQualityView.swift
+++ b/ensure-channel-quality/CallQualityView.swift
@@ -305,14 +305,17 @@ private struct SimpleUIViewWrapper: UIViewRepresentable {
     typealias UIViewType = UIView
 
     let uiView: UIView
-
-    func makeUIView(context: Context) -> UIView {
-        return uiView
-    }
-
+    #if os(iOS)
+    func makeUIView(context: Context) -> UIView { uiView }
     func updateUIView(_ uiView: UIView, context: Context) {
         // You can perform any updates here if needed
     }
+    #elseif os(macOS)
+    func makeNSView(context: Context) -> NSView { uiView }
+    func updateNSView(_ nsView: UIView, context: Context) {
+        // You can perform any updates here if needed
+    }
+    #endif
 }
 
 struct CallQualityView_Previews: PreviewProvider {

--- a/product-workflow/ScreenShareAndVolumeView.swift
+++ b/product-workflow/ScreenShareAndVolumeView.swift
@@ -133,7 +133,9 @@ struct ScreenShareAndVolumeView: View {
             await agoraManager.joinChannel(
                 DocsAppConfig.shared.channel, uid: UInt.random(in: 1500...100_000)
             )
+            #if os(iOS)
             agoraManager.setupScreenSharing()
+            #endif
             agoraManager.screenShareToken = DocsAppConfig.shared.rtcToken
             if !DocsAppConfig.shared.tokenUrl.isEmpty {
                 // try to fetch a valid token, ready for sharing our screen.


### PR DESCRIPTION
- SimpleUIViewWrapper now imports fine to macOS
- `#if os(iOS)` flag around setupScreenSharing call